### PR TITLE
Add --direction flag to specify snowballing direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,22 @@ snowball snowball my-slr-project \
   --email your.email@domain.com
 ```
 
+You can also specify which direction to snowball:
+
+```bash
+# Only backward snowballing (papers referenced by your seeds)
+snowball snowball my-slr-project --direction backward
+
+# Only forward snowballing (papers citing your seeds)
+snowball snowball my-slr-project --direction forward
+
+# Both directions (default)
+snowball snowball my-slr-project --direction both
+```
+
 This will:
-- Find all papers referenced by your seeds (backward)
-- Find all papers citing your seeds (forward)
+- Find all papers referenced by your seeds (backward) - if direction is "backward" or "both"
+- Find all papers citing your seeds (forward) - if direction is "forward" or "both"
 - Apply your configured filters
 - Save all discovered papers for review
 

--- a/src/snowball/cli.py
+++ b/src/snowball/cli.py
@@ -134,7 +134,7 @@ def run_snowball(args) -> None:
     while engine.should_continue_snowballing(project):
         logger.info(f"\nRunning snowball iteration {project.current_iteration + 1}...")
 
-        stats = engine.run_snowball_iteration(project)
+        stats = engine.run_snowball_iteration(project, direction=args.direction)
 
         logger.info(f"Iteration {project.current_iteration} complete:")
         logger.info(f"  - Discovered: {stats['added']} papers")
@@ -483,6 +483,12 @@ def main():
     snowball_parser = subparsers.add_parser("snowball", help="Run snowballing iterations")
     snowball_parser.add_argument("directory", help="Project directory")
     snowball_parser.add_argument("--iterations", type=int, help="Number of iterations to run")
+    snowball_parser.add_argument(
+        "--direction",
+        choices=["backward", "forward", "both"],
+        default="both",
+        help="Snowballing direction: backward (references), forward (citations), or both (default)",
+    )
     snowball_parser.add_argument("--s2-api-key", help="Semantic Scholar API key")
     snowball_parser.add_argument("--email", help="Email for API polite pools")
 


### PR DESCRIPTION
## Summary

Added support for specifying the snowballing direction via a new `--direction` flag:

- **backward**: Only fetch papers referenced by source papers (references)
- **forward**: Only fetch papers that cite source papers (citations)
- **both**: Fetch both directions (default, existing behavior)

## Usage

```bash
# Only backward snowballing (papers referenced by your seeds)
snowball snowball my-slr-project --direction backward

# Only forward snowballing (papers citing your seeds)
snowball snowball my-slr-project --direction forward

# Both directions (default)
snowball snowball my-slr-project --direction both
```

## Changes

- `src/snowball/snowballing.py`: Added `direction` parameter to `run_snowball_iteration()` method with conditional logic for backward/forward fetching
- `src/snowball/cli.py`: Added `--direction` CLI argument with choices `[backward, forward, both]`
- `README.md`: Updated documentation with examples for each direction

## Motivation

This allows users to:
1. **Test citation accuracy**: Backward references are objective (listed in the paper itself), making it easier to verify API results
2. **Focus on specific discovery patterns**: Some reviews may only need one direction
3. **Reduce API calls**: When only one direction is needed

## Testing

- [x] All 316 tests pass
- [x] CLI help shows new `--direction` option
- [ ] Manual testing with real project

Fixes #17

---

@Copilot Please review this feature implementation.