### PR TITLE
Add environment variable support for API credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,11 +263,34 @@ While most APIs work without keys, you'll get higher rate limits with authentica
 
 **Semantic Scholar API Key:**
 1. Register at https://www.semanticscholar.org/product/api
-2. Use with `--s2-api-key` flag
+2. Set via environment variable (recommended) or CLI flag
 
 **Email for Polite Pools:**
 - CrossRef and OpenAlex offer faster service if you provide an email
-- Use with `--email` flag
+- Set via environment variable (recommended) or CLI flag
+
+**Environment Variables (Recommended):**
+
+Add these to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
+
+```bash
+export SEMANTIC_SCHOLAR_API_KEY="your-api-key-here"
+export SNOWBALL_EMAIL="your.email@domain.com"
+```
+
+Then commands will automatically use these credentials:
+```bash
+snowball snowball my-project  # Uses env vars automatically
+```
+
+**CLI Flags (Alternative):**
+
+You can also pass credentials per-command:
+```bash
+snowball snowball my-project --s2-api-key YOUR_KEY --email your@email.com
+```
+
+CLI flags override environment variables when both are set.
 
 ### GROBID (Optional)
 

--- a/src/snowball/cli.py
+++ b/src/snowball/cli.py
@@ -1,5 +1,6 @@
 """Command-line interface for Snowball SLR tool."""
 
+import os
 import sys
 import logging
 import json
@@ -30,6 +31,21 @@ logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
+
+
+def get_api_config(args) -> tuple:
+    """Get API configuration from args or environment variables.
+
+    Environment variables:
+        SEMANTIC_SCHOLAR_API_KEY: Semantic Scholar API key
+        SNOWBALL_EMAIL: Email for API polite pools
+
+    Returns:
+        Tuple of (s2_api_key, email)
+    """
+    s2_api_key = getattr(args, 's2_api_key', None) or os.environ.get('SEMANTIC_SCHOLAR_API_KEY')
+    email = getattr(args, 'email', None) or os.environ.get('SNOWBALL_EMAIL')
+    return s2_api_key, email
 
 
 def init_project(args) -> None:
@@ -80,7 +96,8 @@ def add_seed(args) -> None:
         sys.exit(1)
 
     # Set up API and engine
-    api = APIAggregator(s2_api_key=args.s2_api_key, email=args.email)
+    s2_api_key, email = get_api_config(args)
+    api = APIAggregator(s2_api_key=s2_api_key, email=email)
     pdf_parser = PDFParser(use_grobid=not args.no_grobid)
     engine = SnowballEngine(storage, api, pdf_parser)
 
@@ -126,7 +143,8 @@ def run_snowball(args) -> None:
         sys.exit(1)
 
     # Set up API and engine
-    api = APIAggregator(s2_api_key=args.s2_api_key, email=args.email)
+    s2_api_key, email = get_api_config(args)
+    api = APIAggregator(s2_api_key=s2_api_key, email=email)
     engine = SnowballEngine(storage, api)
 
     # Run iterations
@@ -176,7 +194,8 @@ def review(args) -> None:
         sys.exit(1)
 
     # Set up API and engine
-    api = APIAggregator(s2_api_key=args.s2_api_key, email=args.email)
+    s2_api_key, email = get_api_config(args)
+    api = APIAggregator(s2_api_key=s2_api_key, email=email)
     engine = SnowballEngine(storage, api)
 
     # Launch TUI


### PR DESCRIPTION
## Summary
- Add `SEMANTIC_SCHOLAR_API_KEY` environment variable support
- Add `SNOWBALL_EMAIL` environment variable support  
- CLI flags (`--s2-api-key`, `--email`) take precedence when both are set
- Updated README with documentation

## Test plan
- [x] All 15 CLI tests pass
- [ ] Manual test: set env vars and verify they're used
- [ ] Manual test: verify CLI flags override env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)