### PR TITLE
Add Google Scholar citation update feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,23 @@ snowball export my-slr-project --format csv
 snowball export my-slr-project --format all
 ```
 
+### 6. Update Citation Counts (Optional)
+
+Update citation counts from Google Scholar for more accurate/current data:
+
+```bash
+# Update all papers
+snowball update-citations my-slr-project
+
+# Update only included papers
+snowball update-citations my-slr-project --status included
+
+# Custom delay between requests (default: 5 seconds)
+snowball update-citations my-slr-project --delay 3
+```
+
+**Note:** This uses Google Scholar scraping via the `scholarly` library. Use responsibly with appropriate delays to avoid being rate-limited.
+
 ## Workflow
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dev = [
 grobid = [
     "grobid-client-python>=0.1.0",
 ]
+google-scholar = [
+    "scholarly>=1.7.0",
+]
 
 [project.scripts]
 snowball = "snowball.cli:main"

--- a/src/snowball/apis/google_scholar.py
+++ b/src/snowball/apis/google_scholar.py
@@ -1,0 +1,140 @@
+"""Google Scholar client for citation data."""
+
+import logging
+import time
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class GoogleScholarClient:
+    """Client for fetching citation counts from Google Scholar.
+
+    Uses the scholarly library to scrape Google Scholar.
+    Note: This is scraping, not an official API. Use responsibly with
+    appropriate rate limiting to avoid being blocked.
+    """
+
+    def __init__(self, rate_limit_delay: float = 5.0):
+        """Initialize Google Scholar client.
+
+        Args:
+            rate_limit_delay: Delay between requests in seconds.
+                              Default is 5 seconds to avoid rate limiting.
+        """
+        self.rate_limit_delay = rate_limit_delay
+        self._scholarly = None
+        self._last_request_time = 0
+
+    def _get_scholarly(self):
+        """Lazy load scholarly library."""
+        if self._scholarly is None:
+            try:
+                from scholarly import scholarly
+                self._scholarly = scholarly
+            except ImportError:
+                logger.error("scholarly library not installed. Run: pip install scholarly")
+                raise ImportError("scholarly library required for Google Scholar support")
+        return self._scholarly
+
+    def _rate_limit(self):
+        """Apply rate limiting between requests."""
+        elapsed = time.time() - self._last_request_time
+        if elapsed < self.rate_limit_delay:
+            time.sleep(self.rate_limit_delay - elapsed)
+        self._last_request_time = time.time()
+
+    def get_citation_count(self, title: str) -> Optional[int]:
+        """Get citation count for a paper by title.
+
+        Args:
+            title: Paper title to search for
+
+        Returns:
+            Citation count if found, None otherwise
+        """
+        try:
+            self._rate_limit()
+            scholarly = self._get_scholarly()
+
+            # Search for the paper
+            search_query = scholarly.search_pubs(title)
+            pub = next(search_query, None)
+
+            if pub:
+                # Verify title similarity to avoid false matches
+                found_title = pub.get("bib", {}).get("title", "").lower()
+                if self._titles_match(title.lower(), found_title):
+                    citations = pub.get("num_citations")
+                    if citations is not None:
+                        logger.info(f"Google Scholar: {title[:50]}... -> {citations} citations")
+                        return int(citations)
+                else:
+                    logger.debug(f"Title mismatch: '{title[:30]}' vs '{found_title[:30]}'")
+
+            logger.debug(f"No Google Scholar match for: {title[:50]}")
+            return None
+
+        except StopIteration:
+            return None
+        except Exception as e:
+            logger.warning(f"Google Scholar error for '{title[:50]}': {e}")
+            return None
+
+    def get_citation_count_with_metadata(self, title: str) -> Tuple[Optional[int], Optional[dict]]:
+        """Get citation count and additional metadata for a paper.
+
+        Args:
+            title: Paper title to search for
+
+        Returns:
+            Tuple of (citation_count, metadata_dict) or (None, None) if not found
+        """
+        try:
+            self._rate_limit()
+            scholarly = self._get_scholarly()
+
+            search_query = scholarly.search_pubs(title)
+            pub = next(search_query, None)
+
+            if pub:
+                found_title = pub.get("bib", {}).get("title", "").lower()
+                if self._titles_match(title.lower(), found_title):
+                    citations = pub.get("num_citations")
+                    metadata = {
+                        "google_scholar_title": pub.get("bib", {}).get("title"),
+                        "google_scholar_year": pub.get("bib", {}).get("pub_year"),
+                        "google_scholar_url": pub.get("pub_url"),
+                        "google_scholar_citations": citations,
+                    }
+                    return int(citations) if citations else None, metadata
+
+            return None, None
+
+        except Exception as e:
+            logger.warning(f"Google Scholar error: {e}")
+            return None, None
+
+    def _titles_match(self, title1: str, title2: str, threshold: float = 0.8) -> bool:
+        """Check if two titles are similar enough to be the same paper.
+
+        Uses simple word overlap ratio for matching.
+        """
+        # Normalize titles
+        words1 = set(title1.lower().split())
+        words2 = set(title2.lower().split())
+
+        # Remove common short words
+        stopwords = {'a', 'an', 'the', 'of', 'in', 'on', 'for', 'to', 'and', 'or', 'with'}
+        words1 = words1 - stopwords
+        words2 = words2 - stopwords
+
+        if not words1 or not words2:
+            return False
+
+        # Calculate Jaccard similarity
+        intersection = len(words1 & words2)
+        union = len(words1 | words2)
+        similarity = intersection / union if union > 0 else 0
+
+        return similarity >= threshold

--- a/tests/apis/test_google_scholar.py
+++ b/tests/apis/test_google_scholar.py
@@ -1,0 +1,140 @@
+"""Tests for Google Scholar client."""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+
+
+class TestGoogleScholarClient:
+    """Tests for GoogleScholarClient."""
+
+    def test_init_default_rate_limit(self):
+        """Test default rate limit delay."""
+        from snowball.apis.google_scholar import GoogleScholarClient
+        client = GoogleScholarClient()
+        assert client.rate_limit_delay == 5.0
+
+    def test_init_custom_rate_limit(self):
+        """Test custom rate limit delay."""
+        from snowball.apis.google_scholar import GoogleScholarClient
+        client = GoogleScholarClient(rate_limit_delay=10.0)
+        assert client.rate_limit_delay == 10.0
+
+    def test_titles_match_identical(self):
+        """Test that identical titles match."""
+        from snowball.apis.google_scholar import GoogleScholarClient
+        client = GoogleScholarClient()
+        assert client._titles_match("Test Paper Title", "Test Paper Title") is True
+
+    def test_titles_match_case_insensitive(self):
+        """Test that title matching is case insensitive."""
+        from snowball.apis.google_scholar import GoogleScholarClient
+        client = GoogleScholarClient()
+        assert client._titles_match("Test Paper Title", "test paper title") is True
+
+    def test_titles_match_with_stopwords(self):
+        """Test that stopwords are ignored in matching."""
+        from snowball.apis.google_scholar import GoogleScholarClient
+        client = GoogleScholarClient()
+        assert client._titles_match(
+            "The Analysis of Machine Learning",
+            "Analysis of Machine Learning"
+        ) is True
+
+    def test_titles_no_match(self):
+        """Test that different titles don't match."""
+        from snowball.apis.google_scholar import GoogleScholarClient
+        client = GoogleScholarClient()
+        assert client._titles_match(
+            "Machine Learning in Healthcare",
+            "Deep Learning for Computer Vision"
+        ) is False
+
+    @patch('snowball.apis.google_scholar.GoogleScholarClient._get_scholarly')
+    def test_get_citation_count_found(self, mock_get_scholarly):
+        """Test getting citation count when paper is found."""
+        from snowball.apis.google_scholar import GoogleScholarClient
+
+        # Mock scholarly
+        mock_scholarly = MagicMock()
+        mock_pub = {
+            "bib": {"title": "Test Paper Title"},
+            "num_citations": 42
+        }
+        mock_scholarly.search_pubs.return_value = iter([mock_pub])
+        mock_get_scholarly.return_value = mock_scholarly
+
+        client = GoogleScholarClient(rate_limit_delay=0)
+        result = client.get_citation_count("Test Paper Title")
+
+        assert result == 42
+
+    @patch('snowball.apis.google_scholar.GoogleScholarClient._get_scholarly')
+    def test_get_citation_count_not_found(self, mock_get_scholarly):
+        """Test getting citation count when paper is not found."""
+        from snowball.apis.google_scholar import GoogleScholarClient
+
+        # Mock scholarly returning no results
+        mock_scholarly = MagicMock()
+        mock_scholarly.search_pubs.return_value = iter([])
+        mock_get_scholarly.return_value = mock_scholarly
+
+        client = GoogleScholarClient(rate_limit_delay=0)
+        result = client.get_citation_count("Nonexistent Paper")
+
+        assert result is None
+
+    @patch('snowball.apis.google_scholar.GoogleScholarClient._get_scholarly')
+    def test_get_citation_count_title_mismatch(self, mock_get_scholarly):
+        """Test that mismatched titles return None."""
+        from snowball.apis.google_scholar import GoogleScholarClient
+
+        # Mock scholarly returning a different paper
+        mock_scholarly = MagicMock()
+        mock_pub = {
+            "bib": {"title": "Completely Different Paper"},
+            "num_citations": 100
+        }
+        mock_scholarly.search_pubs.return_value = iter([mock_pub])
+        mock_get_scholarly.return_value = mock_scholarly
+
+        client = GoogleScholarClient(rate_limit_delay=0)
+        result = client.get_citation_count("Test Paper Title")
+
+        assert result is None
+
+    @patch('snowball.apis.google_scholar.GoogleScholarClient._get_scholarly')
+    def test_get_citation_count_handles_error(self, mock_get_scholarly):
+        """Test that errors are handled gracefully."""
+        from snowball.apis.google_scholar import GoogleScholarClient
+
+        # Mock scholarly raising an exception
+        mock_scholarly = MagicMock()
+        mock_scholarly.search_pubs.side_effect = Exception("Network error")
+        mock_get_scholarly.return_value = mock_scholarly
+
+        client = GoogleScholarClient(rate_limit_delay=0)
+        result = client.get_citation_count("Test Paper")
+
+        assert result is None
+
+    @patch('snowball.apis.google_scholar.GoogleScholarClient._get_scholarly')
+    def test_get_citation_count_with_metadata(self, mock_get_scholarly):
+        """Test getting citation count with metadata."""
+        from snowball.apis.google_scholar import GoogleScholarClient
+
+        mock_scholarly = MagicMock()
+        mock_pub = {
+            "bib": {"title": "Test Paper Title", "pub_year": "2023"},
+            "num_citations": 42,
+            "pub_url": "https://example.com/paper"
+        }
+        mock_scholarly.search_pubs.return_value = iter([mock_pub])
+        mock_get_scholarly.return_value = mock_scholarly
+
+        client = GoogleScholarClient(rate_limit_delay=0)
+        citations, metadata = client.get_citation_count_with_metadata("Test Paper Title")
+
+        assert citations == 42
+        assert metadata["google_scholar_title"] == "Test Paper Title"
+        assert metadata["google_scholar_year"] == "2023"
+        assert metadata["google_scholar_url"] == "https://example.com/paper"


### PR DESCRIPTION
## Summary
- New `update-citations` CLI command to fetch citation counts from Google Scholar
- GoogleScholarClient using `scholarly` library for scraping
- Title matching with Jaccard similarity to avoid false matches
- Conservative rate limiting (5s default) to avoid being blocked
- Optional `--status` flag to update only specific paper statuses
- `scholarly` added as optional dependency `[google-scholar]`

## Usage
```bash
# Update all papers
snowball update-citations my-project

# Update only included papers
snowball update-citations my-project --status included

# Custom delay between requests
snowball update-citations my-project --delay 3
```

## Test plan
- [x] 11 new unit tests for GoogleScholarClient
- [x] All 326 tests pass
- [x] Manual test with real project - citations updated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)